### PR TITLE
Build wheel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,21 @@ jobs:
 #    with:
 #      os-variant: ubuntu-24.04
 #      python-version: '3.11'
+
+  build:
+    name: Build
+    needs: formatting
+    runs-on: ubuntu-24.04
+    steps:
+     - uses: actions/checkout@v4
+     - name: Install Node
+       uses: actions/setup-node@v6
+     - name: Install Javascript dependencies
+       run: npm install
+     - name: Typecheck TypeScript
+       run: npm run typecheck
+
+     - name: Install uv
+       uses: astral-sh/setup-uv@v7
+     - name: Typecheck Python
+       run: uv build


### PR DESCRIPTION
Building wheels is non-trivial because of the JavaScript components. But it is fast. So we can do it in CI to check the build.