### PR TITLE
Improve clearing of comboboxes

### DIFF
--- a/js/components/input/comboboxInput.ts
+++ b/js/components/input/comboboxInput.ts
@@ -25,7 +25,6 @@ export interface Options extends InputOptions<string> {
 export class ComboboxInput extends InputComponent<string> {
     private readonly datalist: HTMLDataListElement;
     private readonly searchBar: HTMLInputElement;
-    private readonly clearButton: HTMLButtonElement;
 
     private error: string = "";
     private readonly closeListener: (e: PointerEvent) => void;
@@ -42,10 +41,7 @@ export class ComboboxInput extends InputComponent<string> {
                 this.close();
             },
         );
-        const [insert, clearButton] = InputComponent.createInsert(searchBar, () => {
-            this.setSignaling("");
-            this.searchBar.focus();
-        });
+        const [insert, _] = InputComponent.createInsert(searchBar, null);
         insert.appendChild(createChevron(searchBar));
 
         const container = document.createElement("div");
@@ -57,7 +53,6 @@ export class ComboboxInput extends InputComponent<string> {
 
         this.datalist = datalist;
         this.searchBar = searchBar;
-        this.clearButton = clearButton;
 
         this.searchBar.addEventListener("focus", this.open.bind(this));
         this.searchBar.addEventListener("keydown", (e: KeyboardEvent) => {
@@ -126,19 +121,8 @@ export class ComboboxInput extends InputComponent<string> {
         for (const option of this.datalist.options) {
             option.style.display = "block";
         }
-        this.clearButton.disabled = this.searchBar.value.length === 0;
         this.error = value === null || value === "" ? "" : "Value not recognized";
         this.validate();
-    }
-
-    updated(userTriggered: boolean = true) {
-        if (this.searchBar.value.length > 0) {
-            this.clearButton.style.display = "inline-block";
-        } else {
-            this.clearButton.style.display = "none";
-        }
-
-        super.updated(userTriggered);
     }
 
     get options(): HTMLCollectionOf<HTMLOptionElement> {

--- a/js/components/input/comboboxInput.ts
+++ b/js/components/input/comboboxInput.ts
@@ -16,7 +16,6 @@ export type Choice = {
 
 export interface Options extends InputOptions<string> {
     renderChoice?: (choice: Choice) => HTMLElement;
-    filter?: boolean;
 }
 
 /**
@@ -212,8 +211,6 @@ export class ComboboxInput extends InputComponent<string> {
 
     private open() {
         this.datalist.style.display = "block";
-        // TODO disable filter based on options
-        filterOptions(this.searchBar.value, this.datalist);
     }
 
     private close() {
@@ -266,7 +263,8 @@ function createSearchBar(
 
     let currentFocus: number | null = null;
     searchBar.addEventListener("input", () => {
-        openCombobox(); // This filters and ensures that the list is visible
+        openCombobox();
+        filterOptions(searchBar.value, datalist);
         currentFocus = firstVisibleOption(datalist);
         selectActive(datalist, currentFocus);
     });

--- a/js/components/input/inputComponent.ts
+++ b/js/components/input/inputComponent.ts
@@ -182,16 +182,24 @@ export abstract class InputComponent<T> {
         });
     }
 
+    /** Create a div to show on the right of an input.
+     *
+     * Contains a clear button if `onClear` is not null.
+     */
     protected static createInsert(
         input: HTMLInputElement | HTMLTextAreaElement,
-        onClear: () => void,
-    ): [HTMLElement, HTMLButtonElement] {
-        const button = clearButton(input, onClear);
-
+        onClear: (() => void) | null,
+    ): [HTMLElement, HTMLButtonElement | null] {
         const wrap = document.createElement("div");
         wrap.classList = "cean-input-insert";
-        wrap.append(button);
-        return [wrap, button];
+
+        if (onClear !== null) {
+            const button = clearButton(input, onClear);
+            wrap.append(button);
+            return [wrap, button];
+        } else {
+            return [wrap, null];
+        }
     }
 }
 

--- a/js/components/input/multiTextInput.ts
+++ b/js/components/input/multiTextInput.ts
@@ -14,7 +14,7 @@ export class MultiTextInput extends InputComponent<string[]> {
         const [insert, clearButton] = InputComponent.createInsert(inputElement, () => {
             inputElement.value = "";
             inputElement.focus();
-            clearButton.disabled = true;
+            (clearButton as HTMLButtonElement).disabled = true;
         });
 
         const inputContainer = document.createElement("div");
@@ -32,7 +32,7 @@ export class MultiTextInput extends InputComponent<string[]> {
         super(key, wrap, options);
         this.inputElement = inputElement;
         this.itemsList = itemsList;
-        this.clearButton = clearButton;
+        this.clearButton = clearButton as HTMLButtonElement;
     }
 
     // Custom override so this returns the input element's id, not the wrap element's.

--- a/js/components/input/textInput.ts
+++ b/js/components/input/textInput.ts
@@ -35,7 +35,7 @@ export class TextInput extends InputComponent<string> {
         super(key, container, options);
         this.inputElement = inputElement;
         this.inputElement.placeholder = options.placeholder ?? "";
-        this.clearButton = clearButton;
+        this.clearButton = clearButton as HTMLButtonElement;
 
         // The trim listener must come before the validation listener,
         // so the validation can detect empty strings after trimming.

--- a/js/forms/util.ts
+++ b/js/forms/util.ts
@@ -39,7 +39,9 @@ export function createLabel(
     const info = fieldInfo(key);
 
     const el = document.createElement("label");
-    el.htmlFor = target.id;
+    if (target.id) {
+        el.htmlFor = target.id;
+    }
     el.textContent = label ?? info?.label ?? "Unknown field";
 
     const t = title ?? info?.description;


### PR DESCRIPTION
The clear button was broken in comboboxes. This PR removes the button and instead stops filtering options when the user clicks the search box. This should make for a better UX when using the mouse.