### PR TITLE
Run all CI jobs in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
 
   type-checking:
     name: Type checking
-    needs: formatting
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -41,14 +40,12 @@ jobs:
 
   tests:
     name: Tests
-    needs: formatting
     uses: ./.github/workflows/test.yml
     with:
       python-version: '3.11'
 
   build:
     name: Build
-    needs: formatting
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is no strict need to wait for the formatting job. And that job is quite slow. So we don't save time with delaying the tests.