### PR TITLE
Add ability to lock fields

### DIFF
--- a/js/components/input/comboboxInput.ts
+++ b/js/components/input/comboboxInput.ts
@@ -103,6 +103,8 @@ export class ComboboxInput extends InputComponent<string> {
     }
 
     setSilent(value: string | null) {
+        if (this.locked) return;
+
         deselectAll(this.datalist);
         for (const option of this.datalist.options) {
             if (option.value == value) {
@@ -122,6 +124,11 @@ export class ComboboxInput extends InputComponent<string> {
         }
         this.error = value === null || value === "" ? "" : "Value not recognized";
         this.validate();
+    }
+
+    lock() {
+        super.lock();
+        this.searchBar.disabled = true;
     }
 
     get options(): HTMLCollectionOf<HTMLOptionElement> {

--- a/js/components/input/comboboxManualInput.ts
+++ b/js/components/input/comboboxManualInput.ts
@@ -71,12 +71,19 @@ export class ComboboxManualInput extends InputComponent<string> {
     }
 
     setSilent(value: string | null) {
+        if (this.locked) return;
         this.getActive().setSilent(value);
     }
 
     setSignaling(value: string | null, userTriggered: boolean = true) {
         this.getActive().setSignaling(value, userTriggered);
         this.updated(userTriggered);
+    }
+
+    lock() {
+        super.lock();
+        this.textInput.lock();
+        this.comboboxInput.lock();
     }
 
     private setManual() {

--- a/js/components/input/datetimeInput.ts
+++ b/js/components/input/datetimeInput.ts
@@ -44,6 +44,8 @@ export class DatetimeInput extends InputComponent<Date> {
     }
 
     setSilent(value: Date | string | null) {
+        if (this.locked) return;
+
         if (!value) {
             this.dateElement.value = "";
             this.timeElement.value = "";
@@ -57,5 +59,11 @@ export class DatetimeInput extends InputComponent<Date> {
         const dateString = localDate.toISOString();
         this.dateElement.value = dateString.slice(0, 10);
         this.timeElement.value = dateString.slice(11, 19);
+    }
+
+    lock() {
+        super.lock();
+        this.dateElement.disabled = true;
+        this.timeElement.disabled = true;
     }
 }

--- a/js/components/input/fileInput.ts
+++ b/js/components/input/fileInput.ts
@@ -72,6 +72,14 @@ export class FileInput extends InputComponent<string> {
         return this.textInput.id;
     }
 
+    lock() {
+        super.lock();
+        this.textInput.lock();
+        this.container.querySelectorAll("button").forEach((button) => {
+            button.disabled = true;
+        });
+    }
+
     get value(): string | null {
         if (this.textInput.isValid()) {
             return this.textInput.value;

--- a/js/components/input/inputComponent.ts
+++ b/js/components/input/inputComponent.ts
@@ -15,6 +15,7 @@ export abstract class InputComponent<T> {
     private readonly inputContainer: HTMLElement;
     protected readonly statusElement: HTMLOutputElement;
     protected readonly wrapElement: HTMLDivElement;
+    protected locked: boolean = false;
 
     readonly required: boolean;
     customValidator: Validator<T> | null;
@@ -71,6 +72,10 @@ export abstract class InputComponent<T> {
     setSignaling(value: T | null, userTriggered: boolean = true) {
         this.setSilent(value);
         this.updated(userTriggered);
+    }
+
+    lock() {
+        this.locked = true;
     }
 
     /**

--- a/js/components/input/multiAttachmentInput.ts
+++ b/js/components/input/multiAttachmentInput.ts
@@ -70,6 +70,15 @@ export class MultiAttachmentInput extends InputComponent<Attachment[]> {
         return this.newAttachmentInput.id;
     }
 
+    lock() {
+        super.lock();
+        this.newAttachmentInput.lock();
+        this.attachmentsContainer.classList.add("cean-locked");
+        this.attachments.forEach((view) => {
+            view.lock();
+        });
+    }
+
     private clear() {
         this.attachmentsContainer.replaceChildren();
         this.attachments.splice(0, this.attachments.length);
@@ -178,6 +187,10 @@ class AttachmentView {
 
     get value(): [string, string] {
         return [this.data, this.captionInput.value || this.captionInput.placeholder];
+    }
+
+    lock() {
+        this.captionInput.lock();
     }
 }
 

--- a/js/components/input/multiFileInput.ts
+++ b/js/components/input/multiFileInput.ts
@@ -79,6 +79,15 @@ export class MultiFileInput extends InputComponent<File[]> {
         return this.newFileInput.id;
     }
 
+    lock() {
+        super.lock();
+        this.newFileInput.lock();
+        this.selectedContainer.classList.add("cean-locked");
+        this.selectedFiles.forEach(({ remotePathInput }) => {
+            remotePathInput.lock();
+        });
+    }
+
     private addFileItem(file: File) {
         const [container, localPath, remotePathInput] = createFileItem((p) => {
             this.onInputRemoved(p);

--- a/js/components/input/multiInput.ts
+++ b/js/components/input/multiInput.ts
@@ -53,8 +53,16 @@ export class MultiInput extends InputComponent<string[]> {
     }
 
     setSilent(value: string[] | null) {
+        if (this.locked) return;
         this.selectionContainer.replaceChildren();
         (value ?? []).forEach((val) => this.addItem(val, false));
+    }
+
+    lock() {
+        super.lock();
+        this.underlying.lock();
+        this.underlying.container.remove();
+        this.container.classList.add("cean-locked");
     }
 
     private addItem(value: string | null, update: boolean = true) {

--- a/js/components/input/peopleInput.ts
+++ b/js/components/input/peopleInput.ts
@@ -56,6 +56,14 @@ export class PeopleInput extends InputComponent<Person[]> {
         }
     }
 
+    lock() {
+        super.lock();
+        for (const person of this.peopleComponents.values()) {
+            person.lock();
+        }
+        this.container.classList.add("cean-locked");
+    }
+
     get id(): string {
         // There is no default input element a label could point to.
         return this.peopleContainer.id;
@@ -124,6 +132,12 @@ class PersonInput {
         this.nameInput.setSilent(value?.name ?? null);
         this.emailInput.setSilent(value?.email ?? null);
         this.orcidInput.setSilent(value?.orcid ?? null);
+    }
+
+    lock() {
+        this.nameInput.lock();
+        this.emailInput.lock();
+        this.orcidInput.lock();
     }
 
     get element(): HTMLFieldSetElement {

--- a/js/components/input/radioInput.ts
+++ b/js/components/input/radioInput.ts
@@ -72,6 +72,14 @@ export class RadioInput extends InputComponent<string> {
         return this.fieldset.id;
     }
 
+    lock() {
+        super.lock();
+        for (const checkbox of this.checkboxes()) {
+            checkbox.disabled = true;
+        }
+        this.customInput.disabled = true;
+    }
+
     protected get validationElement(): HTMLElement {
         return this.customInput;
     }

--- a/js/components/input/scientificMetadataInput.ts
+++ b/js/components/input/scientificMetadataInput.ts
@@ -84,6 +84,17 @@ export class ScientificMetadataInput extends InputComponent<ScientificMetadataIt
         return this.tableBody.id;
     }
 
+    lock() {
+        super.lock();
+        for (const input of this.container.querySelectorAll("input")) {
+            input.disabled = true;
+        }
+        for (const button of this.container.querySelectorAll("button")) {
+            button.disabled = true;
+        }
+        this.container.classList.add("cean-locked");
+    }
+
     private addNewRow(item?: ScientificMetadataItem) {
         const newItem = item ?? {};
 

--- a/js/components/input/textInput.ts
+++ b/js/components/input/textInput.ts
@@ -53,6 +53,7 @@ export class TextInput extends InputComponent<string> {
     }
 
     setSilent(value: string | null) {
+        if (this.locked) return;
         this.inputElement.value = value ?? "";
         this.clearButton.disabled = this.inputElement.value.length === 0;
     }
@@ -72,6 +73,11 @@ export class TextInput extends InputComponent<string> {
 
     get id(): string {
         return this.inputElement.id;
+    }
+
+    lock() {
+        super.lock();
+        this.inputElement.disabled = true;
     }
 
     protected get validationElement(): HTMLElement {

--- a/js/datasetUploadWidget.css
+++ b/js/datasetUploadWidget.css
@@ -355,6 +355,12 @@ input.cean-input, select.cean-input, textarea.cean-input {
     }
 }
 
+.cean-locked .cean-scientific-metadata {
+    td:hover {
+        box-shadow: none !important;
+    }
+}
+
 .cean-source-folder {
     display: block;
     margin-bottom: 2em !important;

--- a/js/datasetUploadWidget.css
+++ b/js/datasetUploadWidget.css
@@ -182,6 +182,7 @@ input.cean-input, select.cean-input, textarea.cean-input {
     border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
     background: var(--jp-cell-editor-background);
     color: var(--jp-content-font-color1);
+    padding: 0.2ch 0.5ch;
 
     &:focus-visible {
         outline: none;
@@ -384,7 +385,7 @@ input.cean-input, select.cean-input, textarea.cean-input {
         margin-left: 1em;
         background: var(--jp-layout-color3);
 
-        &:hover {
+        &:hover:not(:disabled) {
             background: var(--jp-layout-color1);
         }
     }
@@ -417,6 +418,11 @@ input.cean-input, select.cean-input, textarea.cean-input {
 
     .cean-button {
         align-self: flex-start;
+    }
+
+    output {
+        /* Same as text inputs */
+        padding: 0.2ch 0.5ch;
     }
 }
 
@@ -517,7 +523,7 @@ input.cean-input, select.cean-input, textarea.cean-input {
     border: none;
     cursor: pointer;
 
-    &:not(:has(:disabled)) {
+    &:not(:has(:disabled), :disabled) {
         &:hover {
             background: var(--jp-input-hover-background);
             color: var(--jp-ui-font-color0);
@@ -528,7 +534,7 @@ input.cean-input, select.cean-input, textarea.cean-input {
         }
     }
 
-    &:has(:disabled) {
+    &:has(:disabled), &:disabled {
         background: var(--jp-input-background);
         color: var(--jp-ui-font-color2);
         cursor: unset;
@@ -541,7 +547,7 @@ input.cean-input, select.cean-input, textarea.cean-input {
 }
 
 .cean-icon-button {
-    &:active {
+    &:active:not(:disabled) {
         box-shadow: none;
         background: var(--jp-input-active-background);
     }

--- a/js/datasetUploadWidget.css
+++ b/js/datasetUploadWidget.css
@@ -608,6 +608,15 @@ input.cean-input, select.cean-input, textarea.cean-input {
     }
 }
 
+.cean-input:disabled {
+    background: var(--jp-layout-color2);
+    border-color: var(--jp-layout-color2);
+
+    & + div .cean-clear-button {
+        display: none;
+    }
+}
+
 .cean-button[type="submit"] {
     /* SciCat brand color */
     background: #27aae1;
@@ -623,10 +632,23 @@ input.cean-input, select.cean-input, textarea.cean-input {
     display: flex;
     flex-wrap: wrap;
     gap: 0.4em;
-    padding-top: 0.4em;
 
     .cean-selected-item {
         margin: 0;
+    }
+}
+
+.cean-selected-items, .cean-compressed-items {
+    margin: 0.4em 0;
+}
+
+.cean-locked {
+    .cean-selected-items, .cean-compressed-items {
+        margin: 0;
+    }
+
+    .cean-button {
+        display: none;
     }
 }
 
@@ -637,6 +659,16 @@ input.cean-input, select.cean-input, textarea.cean-input {
     border: var(--jp-border-width) solid var(--jp-layout-color3);
     border-radius: var(--jp-border-radius);
     margin: 0.4em 0;
+
+    /* Handle margin via parent to deal with locked inputs. */
+
+    &:first-child {
+        margin-top: 0;
+    }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
 
     .cean-item-row {
         display: flex;

--- a/js/datasetUploadWidget.ts
+++ b/js/datasetUploadWidget.ts
@@ -47,7 +47,9 @@ async function render({ model, el }: RenderProps<WidgetModel>) {
         true,
     );
 
+    // lockFields must be after setInitialData to set the data before locks take effect.
     setInitialData(inputs, model.get("initial"));
+    lockFields(inputs, config.lockedFields);
 
     return () => {
         datasetOverview.destroy();
@@ -73,6 +75,17 @@ function setInitialData(
     for (const [key, value] of Object.entries(initialData)) {
         // userTriggered=true so that the fields written here are not overridden by update-handlers
         inputs.get(key)?.setSignaling(value, true);
+    }
+}
+
+function lockFields(inputs: Map<string, InputComponent<any>>, lockedFields: string[]) {
+    for (const name of lockedFields) {
+        const input = inputs.get(name);
+        if (input === undefined) {
+            console.warn(`Cannot lock field '${name}', field does not exist`);
+        } else {
+            input.lock();
+        }
     }
 }
 

--- a/js/models.ts
+++ b/js/models.ts
@@ -9,6 +9,7 @@ export type Config = {
     frontendUrl: string | null;
     scientificMetadataSchema: "plain" | "value-unit";
     fieldDependencies: Record<string, string[]>;
+    lockedFields: string[];
     skipConfirmation: boolean;
 };
 

--- a/src/scicat_widget/_model.py
+++ b/src/scicat_widget/_model.py
@@ -12,6 +12,7 @@ class Config(BaseModel):
     frontendUrl: str | None
     scientificMetadataSchema: ScientificMetadataSchema
     fieldDependencies: dict[str, list[str]]
+    lockedFields: list[str]
     skipConfirmation: bool
 
 

--- a/src/scicat_widget/_widgets.py
+++ b/src/scicat_widget/_widgets.py
@@ -5,7 +5,7 @@ import inspect
 import os
 import pathlib
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -42,9 +42,10 @@ class DatasetUploadWidget(anywidget.AnyWidget):
         /,
         *,
         initial: Dataset | None = None,
+        locked: Iterable[str] = (),
         skip_confirm: bool = False,
     ) -> None:
-        config = _build_config(client, skip_confirm=skip_confirm)
+        config = _build_config(client, locked=locked, skip_confirm=skip_confirm)
         initial_data, static = _collect_initial_data(client, initial)
         super().__init__(
             config=config.model_dump(),
@@ -83,6 +84,7 @@ class DatasetUploadWidget(anywidget.AnyWidget):
 def _build_config(
     client: Client,
     *,
+    locked: Iterable[str],
     skip_confirm: bool,
 ) -> Config:
     profile = client.profile
@@ -93,6 +95,7 @@ def _build_config(
             name: _extract_factory_dependencies(fn)
             for name, fn in profile.field_factories.items()
         },
+        lockedFields=list(locked),
         skipConfirmation=skip_confirm,
     )
 


### PR DESCRIPTION
This PR adds the ability to lock individual dataset fields so that they cannot be modified beyond their initial value and values deduced from those.

This can be useful, e.g., when we provide users with a pre-build function to make a widget and populate it from some initial data. This way, we can guide users better.